### PR TITLE
feat: Add 30days Context option to Dev-User Pickles Report workflow

### DIFF
--- a/.github/workflows/developer-test.yml
+++ b/.github/workflows/developer-test.yml
@@ -35,6 +35,11 @@ on:
         required: false
         default: false
         type: boolean
+      context_30days:
+        description: '30days Context'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   send-report:
@@ -77,6 +82,7 @@ jobs:
         ANALYSIS="${{ github.event.inputs.analysis_type || 'domi' }}"
         DELIVERY="${{ github.event.inputs.delivery_method || 'email_html' }}"
         DAYS="${{ github.event.inputs.days_back || '7' }}"
+        CONTEXT="${{ github.event.inputs.context_30days || 'false' }}"
         
         # 必須パラメータのチェック
         if [[ -z "$SPREADSHEET_ID_DEV" ]]; then
@@ -91,6 +97,7 @@ jobs:
           echo "Analysis Type: $ANALYSIS"
           echo "Delivery Method: $DELIVERY"
           echo "Days Back: $DAYS"
+          echo "30days Context: $CONTEXT"
           echo "Environment variables status:"
           echo "OPENAI_API_KEY: ${OPENAI_API_KEY:+SET}"
           echo "EMAIL_USER: ${EMAIL_USER:+SET}"
@@ -102,8 +109,12 @@ jobs:
         fi
         
         # Google Sheetsからマルチユーザー実行
-        uv run python read_spreadsheet_and_execute_dev.py \
-          --spreadsheet-id "$SPREADSHEET_ID_DEV" \
-          --analysis "$ANALYSIS" \
-          --delivery "$DELIVERY" \
-          --days "$DAYS"
+        CMD="uv run python read_spreadsheet_and_execute_dev.py --spreadsheet-id \"$SPREADSHEET_ID_DEV\" --analysis \"$ANALYSIS\" --delivery \"$DELIVERY\" --days \"$DAYS\""
+        
+        # 30days Contextが有効な場合、--month-contextフラグを追加
+        if [[ "$CONTEXT" == "true" ]]; then
+          CMD="$CMD --month-context"
+        fi
+        
+        # コマンドを実行
+        eval $CMD

--- a/read_spreadsheet_and_execute_dev.py
+++ b/read_spreadsheet_and_execute_dev.py
@@ -107,7 +107,7 @@ class GoogleSheetsReader:
             return []
 
 
-def execute_pickles_for_user(user_data: Dict[str, str], analysis_type: str, delivery_methods: str, days: int = 7) -> bool:
+def execute_pickles_for_user(user_data: Dict[str, str], analysis_type: str, delivery_methods: str, days: int = 7, month_context: bool = False) -> bool:
     """
     指定されたユーザーに対してPicklesを実行
     """
@@ -122,6 +122,10 @@ def execute_pickles_for_user(user_data: Dict[str, str], analysis_type: str, deli
             "--notion-api-key", user_data['notion_api_key'],
             "--language", user_data['language']
         ]
+        
+        # 30days Contextが有効な場合、フラグを追加
+        if month_context:
+            cmd.append("--month-context")
         
         logger.start(f"{user_data['user_name']}のPickles実行", "execution")
 
@@ -159,6 +163,7 @@ def main():
     parser.add_argument("--delivery", default="email_html", help="配信方法")
     parser.add_argument("--days", type=int, default=7, help="取得日数")
     parser.add_argument("--service-account-key", help="サービスアカウントキーファイルのパス")
+    parser.add_argument("--month-context", action="store_true", help="30日間のコンテキストを含めて分析")
     
     args = parser.parse_args()
     
@@ -180,12 +185,12 @@ def main():
         
         logger.info(f"{total_count}人のユーザーに対してPickles分析を実行", "execution", 
                    user_count=total_count, analysis_type=args.analysis, 
-                   delivery=args.delivery, days=args.days)
+                   delivery=args.delivery, days=args.days, month_context=args.month_context)
         
         for i, user_data in enumerate(user_data_list, 1):
             logger.info(f"[{i}/{total_count}] ユーザー処理開始", "execution", 
                        user=user_data['user_name'], progress=f"{i}/{total_count}")
-            if execute_pickles_for_user(user_data, args.analysis, args.delivery, args.days):
+            if execute_pickles_for_user(user_data, args.analysis, args.delivery, args.days, args.month_context):
                 success_count += 1
         
         # 実行結果サマリー


### PR DESCRIPTION
- Added context_30days boolean input to developer-test.yml workflow
- Updated workflow to pass --month-context flag when context is enabled
- Modified read_spreadsheet_and_execute_dev.py to handle month_context parameter
- When enabled, uses _create_context_analysis_prompt() in analyzer.py for 30-day context analysis