### PR TITLE
feat: languageの追加

### DIFF
--- a/.github/workflows/pickles-report-admin.yml
+++ b/.github/workflows/pickles-report-admin.yml
@@ -31,14 +31,6 @@ on:
         required: false
         default: '30'
         type: string
-      language:
-        description: '出力言語'
-        required: false
-        default: 'japanese'
-        type: choice
-        options:
-          - japanese
-          - english
       debug_mode:
         description: 'デバッグモード（詳細ログを出力）'
         required: false
@@ -84,7 +76,6 @@ jobs:
         ANALYSIS="${{ github.event.inputs.analysis_type || 'domi' }}"
         DELIVERY="${{ github.event.inputs.delivery_method || 'email_html' }}"
         DAYS="${{ github.event.inputs.days_back || '30' }}"
-        LANGUAGE="${{ github.event.inputs.language || 'japanese' }}"
         
         # 必須パラメータのチェック
         if [[ -z "$SPREADSHEET_ID" ]]; then
@@ -99,7 +90,6 @@ jobs:
           echo "Analysis Type: $ANALYSIS"
           echo "Delivery Method: $DELIVERY"
           echo "Days Back: $DAYS"
-          echo "Language: $LANGUAGE"
           echo "Environment variables status:"
           echo "OPENAI_API_KEY: ${OPENAI_API_KEY:+SET}"
           echo "EMAIL_USER: ${EMAIL_USER:+SET}"
@@ -115,5 +105,4 @@ jobs:
           --spreadsheet-id "$SPREADSHEET_ID" \
           --analysis "$ANALYSIS" \
           --delivery "$DELIVERY" \
-          --days "$DAYS" \
-          --language "$LANGUAGE"
+          --days "$DAYS"

--- a/.github/workflows/pickles-report-en.yml
+++ b/.github/workflows/pickles-report-en.yml
@@ -34,14 +34,6 @@ on:
         required: false
         default: '30'
         type: string
-      language:
-        description: '出力言語'
-        required: false
-        default: 'english'
-        type: choice
-        options:
-          - japanese
-          - english
       debug_mode:
         description: 'デバッグモード（詳細ログを出力）'
         required: false
@@ -80,6 +72,8 @@ jobs:
       run: |
         # 環境変数から設定を取得
         # 定期実行・手動実行ともにSPREADSHEET_ID_EN_TESTERS_LISTを使用
+        # スプレッドシート構造: EMAIL_TO | NOTION_API_KEY | GOOGLE_DOCS_URL | USER_NAME | LANGUAGE
+        # データソース優先順位: Notion > Google Docs
         if [[ "${{ github.event_name }}" == "schedule" ]]; then
           SPREADSHEET_ID="${{ secrets.SPREADSHEET_ID_EN_TESTERS_LIST }}"
           echo "📅 定期実行: EN Testersスプレッドシートを使用"
@@ -91,7 +85,6 @@ jobs:
         ANALYSIS="${{ github.event.inputs.analysis_type || 'domi' }}"
         DELIVERY="${{ github.event.inputs.delivery_method || 'email_html' }}"
         DAYS="${{ github.event.inputs.days_back || '30' }}"
-        LANGUAGE="${{ github.event.inputs.language || 'english' }}"
         
         # 必須パラメータのチェック
         if [[ -z "$SPREADSHEET_ID" ]]; then
@@ -106,7 +99,6 @@ jobs:
           echo "Analysis Type: $ANALYSIS"
           echo "Delivery Method: $DELIVERY"
           echo "Days Back: $DAYS"
-          echo "Language: $LANGUAGE"
           echo "Environment variables status:"
           echo "OPENAI_API_KEY: ${OPENAI_API_KEY:+SET}"
           echo "EMAIL_USER: ${EMAIL_USER:+SET}"
@@ -122,5 +114,4 @@ jobs:
           --spreadsheet-id "$SPREADSHEET_ID" \
           --analysis "$ANALYSIS" \
           --delivery "$DELIVERY" \
-          --days "$DAYS" \
-          --language "$LANGUAGE"
+          --days "$DAYS"

--- a/.github/workflows/pickles-report-ja.yml
+++ b/.github/workflows/pickles-report-ja.yml
@@ -34,14 +34,6 @@ on:
         required: false
         default: '30'
         type: string
-      language:
-        description: '出力言語'
-        required: false
-        default: 'japanese'
-        type: choice
-        options:
-          - japanese
-          - english
       debug_mode:
         description: 'デバッグモード（詳細ログを出力）'
         required: false
@@ -80,6 +72,8 @@ jobs:
       run: |
         # 環境変数から設定を取得
         # 定期実行・手動実行ともにSPREADSHEET_ID_JA_TESTERS_LISTを使用
+        # スプレッドシート構造: EMAIL_TO | NOTION_API_KEY | GOOGLE_DOCS_URL | USER_NAME | LANGUAGE
+        # データソース優先順位: Notion > Google Docs
         if [[ "${{ github.event_name }}" == "schedule" ]]; then
           SPREADSHEET_ID="${{ secrets.SPREADSHEET_ID_JA_TESTERS_LIST }}"
           echo "📅 定期実行: JA Testersスプレッドシートを使用"
@@ -91,7 +85,6 @@ jobs:
         ANALYSIS="${{ github.event.inputs.analysis_type || 'domi' }}"
         DELIVERY="${{ github.event.inputs.delivery_method || 'email_html' }}"
         DAYS="${{ github.event.inputs.days_back || '30' }}"
-        LANGUAGE="${{ github.event.inputs.language || 'japanese' }}"
         
         # 必須パラメータのチェック
         if [[ -z "$SPREADSHEET_ID" ]]; then
@@ -106,7 +99,6 @@ jobs:
           echo "Analysis Type: $ANALYSIS"
           echo "Delivery Method: $DELIVERY"
           echo "Days Back: $DAYS"
-          echo "Language: $LANGUAGE"
           echo "Environment variables status:"
           echo "OPENAI_API_KEY: ${OPENAI_API_KEY:+SET}"
           echo "EMAIL_USER: ${EMAIL_USER:+SET}"
@@ -122,5 +114,4 @@ jobs:
           --spreadsheet-id "$SPREADSHEET_ID" \
           --analysis "$ANALYSIS" \
           --delivery "$DELIVERY" \
-          --days "$DAYS" \
-          --language "$LANGUAGE"
+          --days "$DAYS"


### PR DESCRIPTION
## Why

  1. 冗長性の除去
    - スプレッドシートに言語列があるのにGitHub Actionsでも指定は重複
    - データソース（スプレッドシート）を単一の真実として統一
  2. ユーザー個別設定の実現
    - 各ユーザーが好みの言語を設定可能
    - マルチユーザー実行で混在言語対応（一部日本語、一
  部英語）
  3. 運用の簡素化
    - GitHub Actions実行時の設定項目削減
    - スプレッドシート管理のみで言語制御

## What

  1. GitHub Actions入力パラメータから言語設定を削除
    - 3つのワークフローファイル（ja/en/admin）からlanguage入力を除去
    - --language引数をコマンドから削除
  2. スプレッドシート言語列の活用
    - 各ユーザーのE列（LANGUAGE）から言語設定を取得
    - デフォルトはjapanese、設定値はjapanese/english（小文字）
  3. read_spreadsheet_and_execute.py修正
    - 言語パラメータをコマンドライン引数から削除
    - ユーザーごとの個別言語設定に完全移行