### PR TITLE
fix: gaの処理で一人失敗した時に全体を止めない

### DIFF
--- a/read_spreadsheet_and_execute.py
+++ b/read_spreadsheet_and_execute.py
@@ -252,8 +252,11 @@ def main():
         if success_count == total_count:
             logger.success("すべてのユーザーの分析が正常完了", "execution")
             sys.exit(0)
+        elif success_count > 0:
+            logger.warning("一部のユーザーで分析に失敗したが、一部成功", "execution")
+            sys.exit(0)  # 部分成功は正常終了扱い
         else:
-            logger.warning("一部のユーザーで分析に失敗", "execution")
+            logger.error("すべてのユーザーで分析に失敗", "execution")
             sys.exit(1)
             
     except Exception as e:


### PR DESCRIPTION
## Why

- 個別処理の失敗で全体が止まってしまっていた。

## What

  1. GitHub Actions の動作: 各バッチ（matrix.batch: [1, 2, 3,
  4]）は独立して並列実行されています
  2. exit code の意味:
    - sys.exit(0) = 正常終了 → GitHub Actionsはそのバッチを成功とみなす
    - sys.exit(1) = エラー終了 → GitHub
  Actionsはそのバッチを失敗とみなし、他のバッチも停止させる可能性
  3. 松村さんの例:
    - バッチ2で松村さんが失敗、他3人が成功 → success_count=3, total_count=4
    - 修正前: sys.exit(1) でバッチ2全体が失敗 → 他のバッチ1,3,4も影響を受ける
    - 修正後: sys.exit(0) でバッチ2は正常終了 → 他のバッチ1,3,4は継続実行
