### PR TITLE
fix: google docs エントリ0 method

### DIFF
--- a/main.py
+++ b/main.py
@@ -86,11 +86,11 @@ class PicklesSystem:
                 # コンテキスト分析用にdays日分のデータを取得
                 logger.start(f"{data_source}からの{days}日間データ取得（コンテキスト用）", "data", days=days)
                 context_data = self._fetch_data(data_source, days)
-                
+
                 if not context_data:
-                    logger.warning("コンテキストデータが見つかりません", "data", source=data_source, days=days)
-                    return {"error": "データが見つかりませんでした"}
-                
+                    logger.warning("コンテキストデータが見つかりません（空データとして処理を継続）", "data", source=data_source, days=days)
+                    context_data = []
+
                 logger.success("コンテキストデータ取得完了", "data", count=len(context_data), source=data_source)
                 
                 # 直近7日分のデータも取得
@@ -107,11 +107,11 @@ class PicklesSystem:
                 # days == 7の場合は通常の処理
                 logger.start(f"{data_source}からのデータ取得", "data", days=days)
                 raw_data = self._fetch_data(data_source, days)
-                
+
                 if not raw_data:
-                    logger.warning("データが見つかりません", "data", source=data_source, days=days)
-                    return {"error": "データが見つかりませんでした"}
-                
+                    logger.warning("データが見つかりません（空データとして処理を継続）", "data", source=data_source, days=days)
+                    raw_data = []
+
                 logger.success("データ取得完了", "data", count=len(raw_data), source=data_source)
                 week_data = raw_data
             

--- a/throughput/analyzer.py
+++ b/throughput/analyzer.py
@@ -237,11 +237,11 @@ class DocumentAnalyzer:
                         analysis_type=analysis_type)
             raise AnalysisError(f"AI分析エラー: {e}")
     
-    def _generate_context_insights(self, week_data: List[Dict[str, str]], context_data: List[Dict[str, str]], 
+    def _generate_context_insights(self, week_data: List[Dict[str, str]], context_data: List[Dict[str, str]],
                                   analysis_type: str, language: str = "日本語") -> str:
         """コンテキスト付きAI分析を実行してインサイトを生成"""
-        if not week_data or not context_data:
-            return "分析対象のデータがありません。"
+        if not week_data and not context_data:
+            return "分析対象のデータがありません。指定期間にジャーナルエントリが見つかりませんでした。"
         
         # データをフォーマット
         formatted_week_data = self._format_data_for_analysis(week_data)


### PR DESCRIPTION
# データ未検出時の挙動改善

## Why（なぜこの変更が必要か）

Google Docsで指定期間（例: 30日間）にジャーナルエントリが存在しない場合、システムがエラーで終了していました。しかし、データが見つからないことは正常な状態の一つであり、エラーとして扱うべきではありません。

## What（何を変更したか）

### 1. データ未検出時の処理を変更（main.py）

**変更前:**
```python
if not context_data:
    logger.warning("コンテキストデータが見つかりません", "data", ...)
    return {"error": "データが見つかりませんでした"}
```

**変更後:**
```python
if not context_data:
    logger.warning("コンテキストデータが見つかりません（空データとして処理を継続）", "data", ...)
    context_data = []
```

- エラーで終了せず、空のリストで処理を継続
- 2箇所修正（days > 7の場合と、days == 7の場合）

### 2. 空データ判定条件の改善（throughput/analyzer.py）

**変更前:**
```python
if not week_data or not context_data:
    return "分析対象のデータがありません。"
```

**変更後:**
```python
if not week_data and not context_data:
    return "分析対象のデータがありません。指定期間にジャーナルエントリが見つかりませんでした。"
```

- OR条件からAND条件に変更（片方にデータがあれば分析可能）
- より具体的なメッセージを返す

### 3. 環境変数設定ファイルの整理（.env, .example.env）

- GitHub Actions環境別（Production/Prototype/Admin）とLocal環境用に階層化
- .example.envを現在の構造に合わせて更新
- サンプル値を実際の形式に即した内容に変更

## 効果

### Before（変更前）
- データが見つからない → エラーで終了 → メール送信なし

### After（変更後）
- データが見つからない → 正常終了 → 「分析対象のデータがありません」というメッセージ付きでメール送信

## その他の変更

- AWS SESのメール設定追加（EMAIL_FROM, EMAIL_USER, EMAIL_PASS, EMAIL_HOST）
- OpenAI API本番キーへの切り替え
- Google Service Account設定の明確化（pickles-reports, pickles-467502）
